### PR TITLE
Feature: added model summary to training scripts

### DIFF
--- a/scripts/train_diffu.py
+++ b/scripts/train_diffu.py
@@ -16,6 +16,7 @@ import utils
 import sys
 import torch
 
+from torchinfo import torchinfo
 
 from autoencoder.CaloEnco import CaloEnco
 
@@ -253,11 +254,9 @@ if __name__ == "__main__":
             std_showers=std_showers,
             E_bins=E_bins,
         ).to(device=device)
-
-    # Added a conditional statement, based off of flags.model, that runs the latent diffusion training pipeline to do the following three things:
-    # Encode data into a latent space with autoencoder
-    # Perform latent diffusion pipeline with encoded data
-    # Store trained latent diffusion model into directory
+        
+        print("\nDiffusion Model Summary:")
+        print(torchinfo.summary(model))
 
     elif flags.model == "Latent_Diffu":
         ae_checkpoint = torch.load(flags.model_loc, map_location=device)
@@ -343,6 +342,9 @@ if __name__ == "__main__":
             max_downsample=max_downsample,
             is_latent=True,
         ).to(device=device)
+
+        print("\nLatent Diffusion Model Summary:") 
+        print(torchinfo.summary(AE))
 
     else:
         print("Model %s not supported!" % flags.model)

--- a/scripts/train_diffu_class.py
+++ b/scripts/train_diffu_class.py
@@ -7,6 +7,7 @@ import torch.optim as optim
 import torch.utils.data as torchdata
 from tqdm import tqdm
 import sys
+from torchinfo import torchinfo
 
 from CaloDiffu import CaloDiffu
 from autoencoder.CaloEnco import CaloEnco
@@ -201,6 +202,9 @@ class DiffusionTrainer:
             E_bins=self.E_bins,
         ).to(device=self.device)
 
+        print("\nDiffusion Model Summary:")
+        print(torchinfo.summary(self.model))
+
     def setup_latent_diffusion_model(self):
         ae_checkpoint = torch.load(self.flags.model_loc, map_location=self.device)
 
@@ -216,6 +220,9 @@ class DiffusionTrainer:
             E_bins=None,
             layer_sizes=self.flags.layer_sizes,
         ).to(device=self.device)
+
+        print("\nAutoEncoder Model Summary:")
+        print(torchinfo.summary(self.AE))
 
         if "model_state_dict" in ae_checkpoint.keys():
             self.AE.load_state_dict(ae_checkpoint["model_state_dict"])
@@ -270,6 +277,9 @@ class DiffusionTrainer:
             max_downsample=max_downsample,
             is_latent=True,
         ).to(device=self.device)
+
+        print("\nLatent Diffusion Model Summary:")
+        print(torchinfo.summary(self.model))
 
     def setup_training_components(self):
         if "model_state_dict" in self.checkpoint.keys():


### PR DESCRIPTION
Added model summary information to training scripts. This should allow us to see the size of the model's parameters which should enable us to diagnose issues and work out optimal hyperparameters faster. 

When a model is run the following information gets logged to the standard out:
Diffusion Model Summary:
=====================================================================================
Layer (type:depth-idx)                                       Param #
=====================================================================================
CaloDiffu                                                    --
├─NNConverter: 1-1                                           --
│    └─ModuleList: 2-1                                       --
│    │    └─Linear: 3-1                                      240
│    │    └─Linear: 3-2                                      480
│    │    └─Linear: 3-3                                      570
│    │    └─Linear: 3-4                                      150
│    │    └─Linear: 3-5                                      150
│    └─ModuleList: 2-2                                       --
│    │    └─Linear: 3-6                                      240
│    │    └─Linear: 3-7                                      480
│    │    └─Linear: 3-8                                      570
│    │    └─Linear: 3-9                                      150
│    │    └─Linear: 3-10                                     150
├─CondUnet: 1-2                                              --
│    └─CylindricalConv: 2-3                                  --
│    │    └─Conv3d: 3-11                                     1,744
│    └─Sequential: 2-4                                       --
│    │    └─Unflatten: 3-12                                  --
│    │    └─Linear: 3-13                                     64
│    │    └─GELU: 3-14                                       --
│    │    └─Linear: 3-15                                     2,112
│    │    └─GELU: 3-16                                       --
│    │    └─Linear: 3-17                                     4,160
│    └─Sequential: 2-5                                       --
│    │    └─Unflatten: 3-18                                  --
│    │    └─Linear: 3-19                                     64
│    │    └─GELU: 3-20                                       --
│    │    └─Linear: 3-21                                     2,112
│    │    └─GELU: 3-22                                       --
│    │    └─Linear: 3-23                                     4,160
│    └─ModuleList: 2-6                                       --
│    │    └─ModuleList: 3-24                                 44,272
│    │    └─ModuleList: 3-25                                 44,272
│    │    └─ModuleList: 3-26                                 105,952
│    └─ModuleList: 2-7                                       --
│    │    └─ModuleList: 3-27                                 66,048
│    │    └─ModuleList: 3-28                                 51,712
│    │    └─ModuleList: 3-29                                 39,408
│    └─ModuleList: 2-8                                       --
│    │    └─Residual: 3-30                                   2,128
│    │    └─Residual: 3-31                                   2,128
│    │    └─Residual: 3-32                                   4,256
│    └─ModuleList: 2-9                                       --
│    │    └─Residual: 3-33                                   2,128
│    │    └─Residual: 3-34                                   2,128
│    │    └─Residual: 3-35                                   2,128
│    └─ResnetBlock: 2-10                                     --
│    │    └─Sequential: 3-36                                 4,128
│    │    └─Block: 3-37                                      27,744
│    │    └─Block: 3-38                                      27,744
│    │    └─Identity: 3-39                                   --
│    └─Residual: 2-11                                        --
│    │    └─PreNorm: 3-40                                    4,256
│    └─ResnetBlock: 2-12                                     --
│    │    └─Sequential: 3-41                                 4,128
│    │    └─Block: 3-42                                      27,744
│    │    └─Block: 3-43                                      27,744
│    │    └─Identity: 3-44                                   --
│    └─Sequential: 2-13                                      --
│    │    └─ResnetBlock: 3-45                                13,920
│    │    └─CylindricalConv: 3-46                            17
=====================================================================================
Total params: 521,581
Trainable params: 521,581
Non-trainable params: 0